### PR TITLE
Deprecate text file objects as input to `load`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,8 +3,7 @@ name: Tests
 on:
   push:
     branches: [ master ]
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+*'
+    tags: [ '[0-9]+.[0-9]+.[0-9]+*' ]
   pull_request:
     branches: [ master ]
 
@@ -17,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.8'
 
     - name: Install pre-commit
       run: |
@@ -33,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [pypy-3.6, 3.6, 3.7, pypy-3.7, 3.8, 3.9, 3.10-dev]
+        python-version: ['pypy-3.6', 'pypy-3.7', '3.6', '3.7', '3.8', '3.9', '3.10-dev']
         os: [ubuntu-latest, macos-latest, windows-latest]
     continue-on-error: ${{ matrix.python-version == '3.10-dev' }}
 
@@ -69,7 +68,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: '3.7'
 
     - name: Install (deps and package)
       run: |
@@ -97,7 +96,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: '3.7'
     - name: Install Flit
       run: |
         pip install "flit==3.2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## **unreleased**
+## 1.2.0
 
 - Deprecated
-  - Text file objects as input to `load`. Binary file objects should be used instead.
+  - Text file objects as input to `load`.
+    Binary file objects should be used instead to avoid opening the file with universal newlines or with an encoding other than UTF-8.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## **unreleased**
+
+- Deprecated
+  - Text file objects as input to `load`. Binary file objects should be used instead.
+
 ## 1.1.0
 
 - Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Deprecated
   - Text file objects as input to `load`.
-    Binary file objects should be used instead to avoid opening the file with universal newlines or with an encoding other than UTF-8.
+    Binary file objects should be used instead to avoid opening a TOML file with universal newlines or with an encoding other than UTF-8.
 
 ## 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ with open("path_to_file/conf.toml", "rb") as f:
 Opening the file in binary mode (with the `"rb"` flag) is highly encouraged.
 Binary mode will enforce decoding the file as UTF-8 with universal newlines disabled,
 both of which are required to correctly parse TOML.
-Support for text file objects may be deprecated for removal in a future release.
+Support for text file objects is deprecated for removal in the next major release.
 
 ### Handle invalid TOML<a name="handle-invalid-toml"></a>
 

--- a/fuzzer/requirements.txt
+++ b/fuzzer/requirements.txt
@@ -1,4 +1,4 @@
 # sudo apt-get install clang
 wheel
-atheris==2.0.0
+atheris==2.0.3
 tomli_w>=0.2.2

--- a/tomli/_parser.py
+++ b/tomli/_parser.py
@@ -11,6 +11,7 @@ from typing import (
     Optional,
     Tuple,
 )
+import warnings
 
 from tomli._re import (
     RE_DATETIME,
@@ -66,6 +67,12 @@ def load(fp: IO, *, parse_float: ParseFloat = float) -> Dict[str, Any]:
     s = fp.read()
     if isinstance(s, bytes):
         s = s.decode()
+    else:
+        warnings.warn(
+            "Text file object support is deprecated in favor of binary file objects."
+            ' Use `open("foo.toml", "rb")` to open the file in binary mode.',
+            DeprecationWarning,
+        )
     return loads(s, parse_float=parse_float)
 
 


### PR DESCRIPTION
For context: https://github.com/hukkin/tomli/issues/99#issuecomment-885273176

Closes https://github.com/hukkin/tomli/issues/99