### PR TITLE
Make TOMLDecodeError show 'tomli' as its module

### DIFF
--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -34,4 +34,4 @@ def test_invalid_char_quotes():
 
 
 def test_module_name():
-    assert tomli.TOMLDecodeError().__module__ == 'tomli'
+    assert tomli.TOMLDecodeError().__module__ == "tomli"

--- a/tomli/__init__.py
+++ b/tomli/__init__.py
@@ -6,4 +6,4 @@ __version__ = "1.2.1"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILIT
 from tomli._parser import TOMLDecodeError, load, loads
 
 # Pretend this exception was created here.
-TOMLDecodeError.__module__ = 'tomli'
+TOMLDecodeError.__module__ = "tomli"


### PR DESCRIPTION
The README and tests show `tomli.TOMLDecodeError` as the error class to catch, which I take to mean it is the public API, but what's printed is `tomli._parser.TOMLDecodeError` because that's the module it's defined in:

```pycon
>>> import tomli
>>> tomli.loads('[foo')
Traceback (most recent call last):
  ...
tomli._parser.TOMLDecodeError: Expected "]" at the end of a table declaration (at end of document)
```

This PR tells the exception class to use 'tomli' as its module so the displayed exception matches the public API:

```pycon
>>> tomli.loads('[foo')
Traceback (most recent call last):
  ...
tomli.TOMLDecodeError: Expected "]" at the end of a table declaration (at end of document)
```

The exception is still defined in its original location, so if anyone saw the original error message and tried to catch the exception from `toml._parser`, it would still work:

```pycon
>>> tomli.TOMLDecodeError is tomli._parser.TOMLDecodeError
True
>>> try:
...     tomli.loads('[foo')
... except tomli._parser.TOMLDecodeError:
...     print('still good')
... 
still good
```