### PR TITLE
Eliminate import cycle in `_re.py`

### DIFF
--- a/tomli/_parser.py
+++ b/tomli/_parser.py
@@ -1,16 +1,6 @@
 import string
 from types import MappingProxyType
-from typing import (
-    Any,
-    BinaryIO,
-    Callable,
-    Dict,
-    FrozenSet,
-    Iterable,
-    NamedTuple,
-    Optional,
-    Tuple,
-)
+from typing import Any, BinaryIO, Dict, FrozenSet, Iterable, NamedTuple, Optional, Tuple
 import warnings
 
 from tomli._re import (
@@ -21,6 +11,7 @@ from tomli._re import (
     match_to_localtime,
     match_to_number,
 )
+from tomli._types import Key, ParseFloat, Pos
 
 ASCII_CTRL = frozenset(chr(i) for i in range(32)) | frozenset(chr(127))
 
@@ -51,11 +42,6 @@ BASIC_STR_ESCAPE_REPLACEMENTS = MappingProxyType(
         "\\\\": "\u005C",  # backslash
     }
 )
-
-# Type annotations
-ParseFloat = Callable[[str], Any]
-Key = Tuple[str, ...]
-Pos = int
 
 
 class TOMLDecodeError(ValueError):

--- a/tomli/_re.py
+++ b/tomli/_re.py
@@ -1,10 +1,9 @@
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from functools import lru_cache
 import re
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import Any, Optional, Union
 
-if TYPE_CHECKING:
-    from tomli._parser import ParseFloat
+from tomli._types import ParseFloat
 
 # E.g.
 # - 00:32:00.999999

--- a/tomli/_types.py
+++ b/tomli/_types.py
@@ -1,0 +1,6 @@
+from typing import Any, Callable, Tuple
+
+# Type annotations
+ParseFloat = Callable[[str], Any]
+Key = Tuple[str, ...]
+Pos = int


### PR DESCRIPTION
At the expense of one additional import.

This is to be able to resolve types from `TYPE_CHECKING` blocks
at runtime  with `sphinx-autodoc-typehints` [1] which might otherwise
involve expensive imports or optional dependencies and where
scoping the tomli import is impracticable.

[1] https://github.com/agronholm/sphinx-autodoc-typehints