### PR TITLE
Slightly speed up execution time of common cases

### DIFF
--- a/tomli/_parser.py
+++ b/tomli/_parser.py
@@ -3,14 +3,7 @@ from types import MappingProxyType
 from typing import Any, BinaryIO, Dict, FrozenSet, Iterable, NamedTuple, Optional, Tuple
 import warnings
 
-from tomli._re import (
-    RE_DATETIME,
-    RE_LOCALTIME,
-    RE_NUMBER,
-    match_to_datetime,
-    match_to_localtime,
-    match_to_number,
-)
+from tomli._re import Patterns, match_to_datetime, match_to_localtime, match_to_number
 from tomli._types import Key, ParseFloat, Pos
 
 ASCII_CTRL = frozenset(chr(i) for i in range(32)) | frozenset(chr(127))
@@ -605,21 +598,21 @@ def parse_value(  # noqa: C901
             return pos + 5, False
 
     # Dates and times
-    datetime_match = RE_DATETIME.match(src, pos)
+    datetime_match = Patterns.datetime.match(src, pos)
     if datetime_match:
         try:
             datetime_obj = match_to_datetime(datetime_match)
         except ValueError as e:
             raise suffixed_err(src, pos, "Invalid date or datetime") from e
         return datetime_match.end(), datetime_obj
-    localtime_match = RE_LOCALTIME.match(src, pos)
+    localtime_match = Patterns.localtime.match(src, pos)
     if localtime_match:
         return localtime_match.end(), match_to_localtime(localtime_match)
 
     # Integers and "normal" floats.
     # The regex will greedily match any type starting with a decimal
     # char, so needs to be located after handling of dates and times.
-    number_match = RE_NUMBER.match(src, pos)
+    number_match = Patterns.number.match(src, pos)
     if number_match:
         return number_match.end(), match_to_number(number_match, parse_float)
 

--- a/tomli/_parser.py
+++ b/tomli/_parser.py
@@ -606,7 +606,6 @@ def parse_value(  # noqa: C901
         if src.startswith("false", pos):
             return pos + 5, False
 
-
     # Arrays
     if char == "[":
         return parse_array(src, pos, parse_float)

--- a/tomli/_parser.py
+++ b/tomli/_parser.py
@@ -3,7 +3,14 @@ from types import MappingProxyType
 from typing import Any, BinaryIO, Dict, FrozenSet, Iterable, NamedTuple, Optional, Tuple
 import warnings
 
-from tomli._re import Patterns, match_to_datetime, match_to_localtime, match_to_number
+from tomli._re import (
+    RE_DATETIME,
+    RE_LOCALTIME,
+    RE_NUMBER,
+    match_to_datetime,
+    match_to_localtime,
+    match_to_number,
+)
 from tomli._types import Key, ParseFloat, Pos
 
 ASCII_CTRL = frozenset(chr(i) for i in range(32)) | frozenset(chr(127))
@@ -599,6 +606,7 @@ def parse_value(  # noqa: C901
         if src.startswith("false", pos):
             return pos + 5, False
 
+
     # Arrays
     if char == "[":
         return parse_array(src, pos, parse_float)
@@ -608,21 +616,21 @@ def parse_value(  # noqa: C901
         return parse_inline_table(src, pos, parse_float)
 
     # Dates and times
-    datetime_match = Patterns.datetime.match(src, pos)
+    datetime_match = RE_DATETIME.match(src, pos)
     if datetime_match:
         try:
             datetime_obj = match_to_datetime(datetime_match)
         except ValueError as e:
             raise suffixed_err(src, pos, "Invalid date or datetime") from e
         return datetime_match.end(), datetime_obj
-    localtime_match = Patterns.localtime.match(src, pos)
+    localtime_match = RE_LOCALTIME.match(src, pos)
     if localtime_match:
         return localtime_match.end(), match_to_localtime(localtime_match)
 
     # Integers and "normal" floats.
     # The regex will greedily match any type starting with a decimal
     # char, so needs to be located after handling of dates and times.
-    number_match = Patterns.number.match(src, pos)
+    number_match = RE_NUMBER.match(src, pos)
     if number_match:
         return number_match.end(), match_to_number(number_match, parse_float)
 

--- a/tomli/_parser.py
+++ b/tomli/_parser.py
@@ -607,13 +607,6 @@ def parse_value(  # noqa: C901
     if char == "{":
         return parse_inline_table(src, pos, parse_float)
 
-    # Integers and "normal" floats.
-    # The regex will greedily match any type starting with a decimal
-    # char, so needs to be located after handling of dates and times.
-    number_match = Patterns.number.match(src, pos)
-    if number_match:
-        return number_match.end(), match_to_number(number_match, parse_float)
-
     # Dates and times
     datetime_match = Patterns.datetime.match(src, pos)
     if datetime_match:
@@ -625,6 +618,13 @@ def parse_value(  # noqa: C901
     localtime_match = Patterns.localtime.match(src, pos)
     if localtime_match:
         return localtime_match.end(), match_to_localtime(localtime_match)
+
+    # Integers and "normal" floats.
+    # The regex will greedily match any type starting with a decimal
+    # char, so needs to be located after handling of dates and times.
+    number_match = Patterns.number.match(src, pos)
+    if number_match:
+        return number_match.end(), match_to_number(number_match, parse_float)
 
     # Special floats
     first_three = src[pos : pos + 3]

--- a/tomli/_re.py
+++ b/tomli/_re.py
@@ -53,6 +53,7 @@ class _LazyPatternCompiler:
         setattr(self, name, pattern)
         return pattern
 
+
 Patterns = _LazyPatternCompiler()
 
 

--- a/tomli/_re.py
+++ b/tomli/_re.py
@@ -10,26 +10,8 @@ from tomli._types import ParseFloat
 # - 00:32:00
 _TIME_RE_STR = r"([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(?:\.([0-9]{1,6})[0-9]*)?"
 
-
-class _LazyPatternCompiler:
-    def __getattr__(self, name: str) -> "re.Pattern":
-        if name == "datetime":
-            pattern = re.compile(
-                fr"""
-([0-9]{{4}})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])  # date, e.g. 1988-10-27
-(?:
-    [T ]
-    {_TIME_RE_STR}
-    (?:(Z)|([+-])([01][0-9]|2[0-3]):([0-5][0-9]))?     # optional time offset
-)?
-""",
-                flags=re.VERBOSE,
-            )
-        elif name == "localtime":
-            pattern = re.compile(_TIME_RE_STR)
-        elif name == "number":
-            pattern = re.compile(
-                r"""
+RE_NUMBER = re.compile(
+    r"""
 0
 (?:
     x[0-9A-Fa-f](?:_?[0-9A-Fa-f])*   # hex
@@ -45,16 +27,20 @@ class _LazyPatternCompiler:
     (?:[eE][+-]?[0-9](?:_?[0-9])*)?  # optional exponent part
 )
 """,
-                flags=re.VERBOSE,
-            )
-        else:  # pragma: no cover
-            raise AttributeError(f"Unknown pattern: {name}")
-
-        setattr(self, name, pattern)
-        return pattern
-
-
-Patterns = _LazyPatternCompiler()
+    flags=re.VERBOSE,
+)
+RE_LOCALTIME = re.compile(_TIME_RE_STR)
+RE_DATETIME = re.compile(
+    fr"""
+([0-9]{{4}})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])  # date, e.g. 1988-10-27
+(?:
+    [T ]
+    {_TIME_RE_STR}
+    (?:(Z)|([+-])([01][0-9]|2[0-3]):([0-5][0-9]))?     # optional time offset
+)?
+""",
+    flags=re.VERBOSE,
+)
 
 
 def match_to_datetime(match: "re.Match") -> Union[datetime, date]:


### PR DESCRIPTION
I'm wrapping up re-writing a CLI tool where responsiveness is critical and during the switch from `toml` to `tomli` I noticed load time increased by ~1-2 milliseconds. This PR brings it down the equivalent amount.

If you don't like the singleton you can eventually use https://www.python.org/dev/peps/pep-0562/ but I haven't benchmarked that way.