### PR TITLE
Make first arg of `load` and `loads` positional only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Removed
   - Python 3.6 support
   - Support for text file objects as `load` input. Use binary file objects instead.
+  - First argument of `load` and `loads` can no longer be passed by keyword.
 - Improved
   - Raise an error when dotted keys define values outside the "current table".
     Technically speaking TOML v1.0.0 does allow such assignments

--- a/tomli/_parser.py
+++ b/tomli/_parser.py
@@ -50,18 +50,18 @@ class TOMLDecodeError(ValueError):
     """An error raised if a document is not valid TOML."""
 
 
-def load(fp: BinaryIO, *, parse_float: ParseFloat = float) -> dict[str, Any]:
+def load(__fp: BinaryIO, *, parse_float: ParseFloat = float) -> dict[str, Any]:
     """Parse TOML from a binary file object."""
-    s = fp.read().decode()
+    s = __fp.read().decode()
     return loads(s, parse_float=parse_float)
 
 
-def loads(s: str, *, parse_float: ParseFloat = float) -> dict[str, Any]:  # noqa: C901
+def loads(__s: str, *, parse_float: ParseFloat = float) -> dict[str, Any]:  # noqa: C901
     """Parse TOML from a string."""
 
     # The spec allows converting "\r\n" to "\n", even in string
     # literals. Let's do so to simplify parsing.
-    src = s.replace("\r\n", "\n")
+    src = __s.replace("\r\n", "\n")
     pos = 0
     out = Output(NestedDict(), Flags())
     header: Key = ()


### PR DESCRIPTION
[pickle.loads](https://bugs.python.org/issue39435) is positional only, and other stdlib `loads` will likely be revised in the future.