### PR TITLE
Allow lower case "t" and "z" in datetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - Python 3.6 support
   - Support for text file objects as `load` input. Use binary file objects instead.
   - First argument of `load` and `loads` can no longer be passed by keyword.
+- Fixed
+  - Allow lower case "t" and "z" in datetimes
 - Improved
   - Raise an error when dotted keys define values outside the "current table".
     Technically speaking TOML v1.0.0 does allow such assignments

--- a/tomli/_re.py
+++ b/tomli/_re.py
@@ -36,9 +36,9 @@ RE_DATETIME = re.compile(
     fr"""
 ([0-9]{{4}})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])  # date, e.g. 1988-10-27
 (?:
-    [T ]
+    [Tt ]
     {_TIME_RE_STR}
-    (?:(Z)|([+-])([01][0-9]|2[0-3]):([0-5][0-9]))?     # optional time offset
+    (?:([Zz])|([+-])([01][0-9]|2[0-3]):([0-5][0-9]))?  # optional time offset
 )?
 """,
     flags=re.VERBOSE,


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc3339#section-5.6