### PR TITLE
Use relative imports within package

### DIFF
--- a/tomli/__init__.py
+++ b/tomli/__init__.py
@@ -3,7 +3,7 @@
 __all__ = ("loads", "load", "TOMLDecodeError")
 __version__ = "2.0.0"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
 
-from tomli._parser import TOMLDecodeError, load, loads
+from ._parser import TOMLDecodeError, load, loads
 
 # Pretend this exception was created here.
 TOMLDecodeError.__module__ = __name__

--- a/tomli/_parser.py
+++ b/tomli/_parser.py
@@ -5,7 +5,7 @@ import string
 from types import MappingProxyType
 from typing import Any, BinaryIO, NamedTuple
 
-from tomli._re import (
+from ._re import (
     RE_DATETIME,
     RE_LOCALTIME,
     RE_NUMBER,
@@ -13,7 +13,7 @@ from tomli._re import (
     match_to_localtime,
     match_to_number,
 )
-from tomli._types import Key, ParseFloat, Pos
+from ._types import Key, ParseFloat, Pos
 
 ASCII_CTRL = frozenset(chr(i) for i in range(32)) | frozenset(chr(127))
 

--- a/tomli/_re.py
+++ b/tomli/_re.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 import re
 from typing import Any
 
-from tomli._types import ParseFloat
+from ._types import ParseFloat
 
 # E.g.
 # - 00:32:00.999999


### PR DESCRIPTION
This has no benefit to you, as far as I know, but it simplifies vendoring tomli (as it looks like I need to in flit_core), because the absolute imports need to be modified when vendoring, whereas relative ones don't.

It is a fairly minor benefit for relatively few people, so feel free to reject this if you prefer the absolute imports. But I thought it worth making the PR. :slightly_smiling_face: 