### PR TITLE
Compile code with Mypyc

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,10 +4,6 @@ tag = True
 tag_name = {new_version}
 current_version = 2.0.0
 
-[bumpversion:file:pyproject.toml]
-search = version = "{current_version}"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
-replace = version = "{new_version}"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
-
 [bumpversion:file:src/tomli/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,8 @@ on:
 env:
   CIBW_TEST_COMMAND: python -m unittest
   CIBW_SKIP: pp*
+  # Pass through to container
+  CIBW_ENVIRONMENT_PASS_LINUX: HATCH_BUILD_HOOKS_ENABLE
 
 jobs:
 
@@ -51,9 +53,6 @@ jobs:
     - name: Install package and test deps
       run: |
         pip install . coverage
-      env:
-        # So coverage only uses pure Python files
-        HATCH_BUILD_NO_HOOKS: 'true'
 
     - name: Test with unittest
       run: |
@@ -79,6 +78,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.3.0
       env:
         CIBW_ARCHS_MACOS: x86_64
+        HATCH_BUILD_HOOKS_ENABLE: 'true'
 
     - uses: actions/upload-artifact@v2
       with:
@@ -98,8 +98,6 @@ jobs:
 
     - name: Build
       run: python -m build
-      env:
-        HATCH_BUILD_NO_HOOKS: 'true'
 
     - uses: actions/upload-artifact@v2
       with:
@@ -128,6 +126,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.3.0
       env:
         CIBW_ARCHS_LINUX: aarch64
+        HATCH_BUILD_HOOKS_ENABLE: 'true'
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  CIBW_TEST_COMMAND: python -m unittest
+  CIBW_SKIP: pp*
+
 jobs:
 
   linters:
@@ -47,6 +51,9 @@ jobs:
     - name: Install package and test deps
       run: |
         pip install . coverage
+      env:
+        # So coverage only uses pure Python files
+        HATCH_BUILD_NO_HOOKS: 'true'
 
     - name: Test with unittest
       run: |
@@ -57,11 +64,85 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
       uses: codecov/codecov-action@v2
 
+  binary-wheels-standard:
+    name: Binary wheels for ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.3.0
+      env:
+        CIBW_ARCHS_MACOS: x86_64
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: artifacts
+        path: wheelhouse/*.whl
+        if-no-files-found: error
+
+  pure-python-wheel-and-sdist:
+    name: Build a pure Python wheel and source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install build dependencies
+      run: python -m pip install --upgrade build
+
+    - name: Build
+      run: python -m build
+      env:
+        HATCH_BUILD_NO_HOOKS: 'true'
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: artifacts
+        path: dist/*
+        if-no-files-found: error
+
+  binary-wheels-arm:
+    name: Build Linux wheels for ARM
+    runs-on: ubuntu-latest
+    # Very slow, no need to run on PRs
+    if: >
+      github.event_name == 'push'
+      &&
+      (github.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags'))
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: arm64
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.3.0
+      env:
+        CIBW_ARCHS_LINUX: aarch64
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: artifacts
+        path: wheelhouse/*.whl
+        if-no-files-found: error
+
   allgood:
     runs-on: ubuntu-latest
     needs:
     - tests
     - linters
+    - binary-wheels-standard
+    - pure-python-wheel-and-sdist
+    - binary-wheels-arm
     steps:
     - run: echo "Great success!"
 
@@ -71,20 +152,14 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/download-artifact@v2
       with:
-        python-version: '3.7'
-    - name: Install build and publish tools
-      run: |
-        pip install build twine
-    - name: Build and check
-      run: |
-        rm -rf dist/ && python -m build
-        twine check --strict dist/*
-    - name: Publish
-      run: |
-        twine upload dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        name: artifacts
+        path: dist
+
+    - name: Push build artifacts to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        skip_existing: true
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling~=0.5"]
+requires = ["hatchling~=0.6"]
 build-backend = "hatchling.build"
 
 [project]
@@ -44,6 +44,7 @@ packages = ["/src/tomli"]
 zip-safe = false
 
 [tool.hatch.build.targets.wheel.hooks.mypyc]
+enable-by-default = false
 dependencies = ["hatch-mypyc>=0.4"]
 # Seems to be slightly faster in benchmark
 options = { separate = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,14 @@
 [build-system]
-requires = ["flit_core>=3.2.0,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling~=0.5"]
+build-backend = "hatchling.build"
 
 [project]
 name = "tomli"
-version = "2.0.0"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
 description = "A lil' TOML parser"
 authors = [
     { name = "Taneli Hukkinen", email = "hukkin@users.noreply.github.com" },
 ]
-license = { file = "LICENSE" }
+license = "MIT"
 requires-python = ">=3.7"
 readme = "README.md"
 classifiers = [
@@ -28,10 +27,26 @@ classifiers = [
     "Typing :: Typed",
 ]
 keywords = ["toml"]
+dynamic = ["version"]
 
 [project.urls]
 "Homepage" = "https://github.com/hukkin/tomli"
 "Changelog" = "https://github.com/hukkin/tomli/blob/master/CHANGELOG.md"
+
+[tool.hatch.version]
+path = "src/tomli/__init__.py"
+
+[tool.hatch.build.targets.sdist]
+include = ["/src"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["/src/tomli"]
+zip-safe = false
+
+[tool.hatch.build.targets.wheel.hooks.mypyc]
+dependencies = ["hatch-mypyc>=0.4"]
+# Seems to be slightly faster in benchmark
+options = { separate = true }
 
 
 [tool.isort]

--- a/src/tomli/__init__.py
+++ b/src/tomli/__init__.py
@@ -4,6 +4,3 @@ __all__ = ("loads", "load", "TOMLDecodeError")
 __version__ = "2.0.0"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
 
 from ._parser import TOMLDecodeError, load, loads
-
-# Pretend this exception was created here.
-TOMLDecodeError.__module__ = __name__

--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 import string
 from types import MappingProxyType
-from typing import Any, BinaryIO, NamedTuple
+from typing import Any, BinaryIO, ClassVar, NamedTuple
 
 from ._re import (
     RE_DATETIME,
@@ -125,10 +125,10 @@ class Flags:
     """Flags that map to parsed keys/namespaces."""
 
     # Marks an immutable namespace (inline array or inline table).
-    FROZEN = 0
+    FROZEN: ClassVar = 0
     # Marks a nest that has been explicitly created and can no longer
     # be opened using the "[table]" syntax.
-    EXPLICIT_NEST = 1
+    EXPLICIT_NEST: ClassVar = 1
 
     def __init__(self) -> None:
         self._flags: dict[str, dict] = {}
@@ -174,8 +174,8 @@ class Flags:
             cont = inner_cont["nested"]
         key_stem = key[-1]
         if key_stem in cont:
-            cont = cont[key_stem]
-            return flag in cont["flags"] or flag in cont["recursive_flags"]
+            stem_cont = cont[key_stem]
+            return flag in stem_cont["flags"] or flag in stem_cont["recursive_flags"]
         return False
 
 
@@ -317,8 +317,8 @@ def key_value_rule(
     key_parent, key_stem = key[:-1], key[-1]
     abs_key_parent = header + key_parent
 
-    relative_path_cont_keys = (header + key[:i] for i in range(1, len(key)))
-    for cont_key in relative_path_cont_keys:
+    for i in range(1, len(key)):
+        cont_key = header + key[:i]
         # Check that dotted key syntax does not redefine an existing table
         if out.flags.is_(cont_key, Flags.EXPLICIT_NEST):
             raise suffixed_err(src, pos, f"Cannot redefine namespace {cont_key}")

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -34,6 +34,3 @@ class TestError(unittest.TestCase):
         with self.assertRaises(tomli.TOMLDecodeError) as exc_info:
             tomli.loads("v = '\n'")
         self.assertTrue(" '\\n' " in str(exc_info.exception))
-
-    def test_module_name(self):
-        self.assertEqual(tomli.TOMLDecodeError().__module__, "tomli")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -80,7 +80,7 @@ class TestMiscellaneous(unittest.TestCase):
         pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
         with open(pyproject_path, "rb") as f:
             pyproject = tomli.load(f)
-        self.assertEqual(pyproject["project"]["version"], tomli.__version__)
+            assert pyproject["project"]["name"] == "tomli"
 
     def test_inline_array_recursion_limit(self):
         nest_count = 470


### PR DESCRIPTION
Hello again! Let me know what you think 😄 

This PR compiles code with [Mypyc](https://github.com/mypyc/mypyc). To do so, I've switched the build system to `hatchling` in order to use the [hatch-mypyc](https://github.com/ofek/hatch-mypyc) build hook plugin. Hatchling is the minimal build backend of [Hatch](https://github.com/ofek/hatch) (v1 rewrite of CLI being released next week). You can think of it as the same distinction between `flit-core` & `flit` or `poetry-core` & `poetry`, with `hatchling` being more similar to `flit-core` in that only accepted standards are used e.g. project metadata format ([PEP 621](https://www.python.org/dev/peps/pep-0621/)), dependency specification ([PEP 631](https://www.python.org/dev/peps/pep-0631/)), etc.

I added binary wheels to the release workflow using the now ubiquitous [cibuildwheel](https://github.com/pypa/cibuildwheel). Here is an example of the files produced: https://pypi.org/project/hatch-showcase/#files

The only thing I couldn't preserve was the hack where we change the `__module__` of `TOMLDecodeError`.

On my Windows machine, `tox -e benchmark` shows a 2-3x performance improvement.