### PR TITLE
Make testing another package name a one line change

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,5 @@
 __all__ = ("tomllib",)
 
+# By changing this one line, we can run the tests against
+# a different module name.
 import tomli as tomllib

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ("tomllib",)
+
+import tomli as tomllib

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,39 +1,39 @@
 import unittest
 
-import tomli
+from . import tomllib
 
 
 class TestError(unittest.TestCase):
     def test_line_and_col(self):
-        with self.assertRaises(tomli.TOMLDecodeError) as exc_info:
-            tomli.loads("val=.")
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads("val=.")
         self.assertEqual(str(exc_info.exception), "Invalid value (at line 1, column 5)")
 
-        with self.assertRaises(tomli.TOMLDecodeError) as exc_info:
-            tomli.loads(".")
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads(".")
         self.assertEqual(
             str(exc_info.exception), "Invalid statement (at line 1, column 1)"
         )
 
-        with self.assertRaises(tomli.TOMLDecodeError) as exc_info:
-            tomli.loads("\n\nval=.")
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads("\n\nval=.")
         self.assertEqual(str(exc_info.exception), "Invalid value (at line 3, column 5)")
 
-        with self.assertRaises(tomli.TOMLDecodeError) as exc_info:
-            tomli.loads("\n\n.")
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads("\n\n.")
         self.assertEqual(
             str(exc_info.exception), "Invalid statement (at line 3, column 1)"
         )
 
     def test_missing_value(self):
-        with self.assertRaises(tomli.TOMLDecodeError) as exc_info:
-            tomli.loads("\n\nfwfw=")
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads("\n\nfwfw=")
         self.assertEqual(str(exc_info.exception), "Invalid value (at end of document)")
 
     def test_invalid_char_quotes(self):
-        with self.assertRaises(tomli.TOMLDecodeError) as exc_info:
-            tomli.loads("v = '\n'")
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads("v = '\n'")
         self.assertTrue(" '\\n' " in str(exc_info.exception))
 
     def test_module_name(self):
-        self.assertEqual(tomli.TOMLDecodeError().__module__, "tomli")
+        self.assertEqual(tomllib.TOMLDecodeError().__module__, tomllib.__name__)

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -2,8 +2,7 @@ import json
 from pathlib import Path
 import unittest
 
-import tomli
-from . import burntsushi
+from . import burntsushi, tomllib
 
 DATA_DIR = Path(__file__).parent / "data" / "extras"
 
@@ -25,14 +24,14 @@ class TestExtraCases(unittest.TestCase):
                 except UnicodeDecodeError:
                     # Some BurntSushi tests are not valid UTF-8. Skip those.
                     continue
-                with self.assertRaises(tomli.TOMLDecodeError):
-                    tomli.loads(toml_str)
+                with self.assertRaises(tomllib.TOMLDecodeError):
+                    tomllib.loads(toml_str)
 
     def test_valid(self):
         for valid, expected in zip(VALID_FILES, VALID_FILES_EXPECTED):
             with self.subTest(msg=valid.stem):
                 toml_str = valid.read_bytes().decode()
-                actual = tomli.loads(toml_str)
+                actual = tomllib.loads(toml_str)
                 actual = burntsushi.convert(actual)
                 expected = burntsushi.normalize(expected)
                 self.assertEqual(actual, expected)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import tempfile
 import unittest
 
-import tomli
+from . import tomllib
 
 
 class TestMiscellaneous(unittest.TestCase):
@@ -17,7 +17,7 @@ class TestMiscellaneous(unittest.TestCase):
             file_path.write_text(content)
 
             with open(file_path, "rb") as bin_f:
-                actual = tomli.load(bin_f)
+                actual = tomllib.load(bin_f)
         self.assertEqual(actual, expected)
 
     def test_parse_float(self):
@@ -30,7 +30,7 @@ class TestMiscellaneous(unittest.TestCase):
               notnum2=-nan
               notnum3=+nan
               """
-        obj = tomli.loads(doc, parse_float=D)
+        obj = tomllib.loads(doc, parse_float=D)
         expected = {
             "val": D("0.1"),
             "biggest1": D("inf"),
@@ -53,7 +53,7 @@ class TestMiscellaneous(unittest.TestCase):
               [bliibaa.diibaa]
               offsettime=[1979-05-27T00:32:00.999999-07:00]
               """
-        obj = tomli.loads(doc)
+        obj = tomllib.loads(doc)
         obj_copy = copy.deepcopy(obj)
         self.assertEqual(obj_copy, obj)
         expected_obj = {
@@ -79,15 +79,15 @@ class TestMiscellaneous(unittest.TestCase):
     def test_own_pyproject(self):
         pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
         with open(pyproject_path, "rb") as f:
-            pyproject = tomli.load(f)
-        self.assertEqual(pyproject["project"]["version"], tomli.__version__)
+            pyproject = tomllib.load(f)
+        self.assertEqual(pyproject["project"]["version"], tomllib.__version__)
 
     def test_inline_array_recursion_limit(self):
         nest_count = 470
         recursive_array_toml = "arr = " + nest_count * "[" + nest_count * "]"
-        tomli.loads(recursive_array_toml)
+        tomllib.loads(recursive_array_toml)
 
     def test_inline_table_recursion_limit(self):
         nest_count = 310
         recursive_table_toml = nest_count * "key = {" + nest_count * "}"
-        tomli.loads(recursive_table_toml)
+        tomllib.loads(recursive_table_toml)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -76,12 +76,6 @@ class TestMiscellaneous(unittest.TestCase):
         }
         self.assertEqual(obj_copy, expected_obj)
 
-    def test_own_pyproject(self):
-        pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
-        with open(pyproject_path, "rb") as f:
-            pyproject = tomllib.load(f)
-        self.assertEqual(pyproject["project"]["version"], tomllib.__version__)
-
     def test_inline_array_recursion_limit(self):
         nest_count = 470
         recursive_array_toml = "arr = " + nest_count * "[" + nest_count * "]"

--- a/tests/test_toml_compliance.py
+++ b/tests/test_toml_compliance.py
@@ -2,8 +2,7 @@ import json
 from pathlib import Path
 import unittest
 
-import tomli
-from . import burntsushi
+from . import burntsushi, tomllib
 
 
 class MissingFile:
@@ -35,8 +34,8 @@ class TestTOMLCompliance(unittest.TestCase):
         for invalid in INVALID_FILES:
             with self.subTest(msg=invalid.stem):
                 toml_str = invalid.read_bytes().decode()
-                with self.assertRaises(tomli.TOMLDecodeError):
-                    tomli.loads(toml_str)
+                with self.assertRaises(tomllib.TOMLDecodeError):
+                    tomllib.loads(toml_str)
 
     def test_valid(self):
         for valid, expected in zip(VALID_FILES, VALID_FILES_EXPECTED):
@@ -46,7 +45,7 @@ class TestTOMLCompliance(unittest.TestCase):
                     # to allow that in a nice way.
                     continue
                 toml_str = valid.read_bytes().decode()
-                actual = tomli.loads(toml_str)
+                actual = tomllib.loads(toml_str)
                 actual = burntsushi.convert(actual)
                 expected = burntsushi.normalize(expected)
                 self.assertEqual(actual, expected)


### PR DESCRIPTION
This can be useful if PEP 680 is accepted and Tomli becomes a stdlib backport.