### PR TITLE
ParseFloat should return a Number, not Any object

### DIFF
--- a/src/tomli/_types.py
+++ b/src/tomli/_types.py
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: 2021 Taneli Hukkinen
 # Licensed to PSF under a Contributor Agreement.
 
-from typing import Any, Callable, Tuple
+from numbers import Number
+from typing import Callable, Tuple
 
 # Type annotations
-ParseFloat = Callable[[str], Any]
+ParseFloat = Callable[[str], Number]
 Key = Tuple[str, ...]
 Pos = int


### PR DESCRIPTION
Since there's already a restriction to not return a dict or a list, it wouldn't hurt to restrict this further to only numbers.

N.B. `issubclass(decimal.Decimal, numbers.Real) == False` so we can not use `Real`.