### PR TITLE
Add \xHH Unicode escape code to basic strings

### DIFF
--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -465,7 +465,7 @@ def parse_inline_table(src: str, pos: Pos, parse_float: ParseFloat) -> tuple[Pos
         pos = skip_chars(src, pos, TOML_WS)
 
 
-def parse_basic_str_escape(
+def parse_basic_str_escape(  # noqa: C901
     src: str, pos: Pos, *, multiline: bool = False
 ) -> tuple[Pos, str]:
     escape_id = src[pos : pos + 2]
@@ -484,6 +484,8 @@ def parse_basic_str_escape(
             pos += 1
         pos = skip_chars(src, pos, TOML_WS_AND_NEWLINE)
         return pos, ""
+    if escape_id == "\\x":
+        return parse_hex_char(src, pos, 2)
     if escape_id == "\\u":
         return parse_hex_char(src, pos, 4)
     if escape_id == "\\U":

--- a/tests/data/valid/multiline-basic-str/replacements.json
+++ b/tests/data/valid/multiline-basic-str/replacements.json
@@ -1,0 +1,5 @@
+{
+  "tab": {"type":"string","value":"\t"},
+  "upper-j": {"type":"string","value":"J"},
+  "upper-j-2": {"type":"string","value":"J"}
+}

--- a/tests/data/valid/multiline-basic-str/replacements.toml
+++ b/tests/data/valid/multiline-basic-str/replacements.toml
@@ -1,0 +1,3 @@
+tab = "\x09"
+upper-j = "\x4a"
+upper-j-2 = "\x4A"


### PR DESCRIPTION
Update tests and merge when https://github.com/toml-lang/toml/pull/796 makes it into a TOML release.