### PR TITLE
Support Python 3.11 final

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['pypy-3.7', '3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['pypy-3.7', '3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, macos-latest, windows-latest]
     continue-on-error: ${{ matrix.python-version == '3.11-dev' }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -51,10 +47,10 @@ profile = "black"
 legacy_tox_ini = '''
 [tox]
 # Only run unittest envs when no args given to tox
-envlist = py{37,38,39,310}
+envlist = py{37,38,39,310,311}
 isolated_build = True
 
-[testenv:py{37,38,39,310}]
+[testenv:py{37,38,39,310,311}]
 description = run tests against a built package
 commands =
     python -m unittest {posargs}


### PR DESCRIPTION
While Python 3.11 now ships with [tomllib](https://docs.python.org/3.11/library/tomllib.html), make sure existing code based on tomli will work for at least a couple upcoming Python releases.