### PR TITLE
Type annotate as `IO[bytes]`, not `BinaryIO`

### DIFF
--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 import string
 from types import MappingProxyType
-from typing import Any, BinaryIO, NamedTuple
+from typing import IO, Any, NamedTuple
 
 from ._re import (
     RE_DATETIME,
@@ -54,7 +54,7 @@ class TOMLDecodeError(ValueError):
     """An error raised if a document is not valid TOML."""
 
 
-def load(__fp: BinaryIO, *, parse_float: ParseFloat = float) -> dict[str, Any]:
+def load(__fp: IO[bytes], *, parse_float: ParseFloat = float) -> dict[str, Any]:
     """Parse TOML from a binary file object."""
     b = __fp.read()
     try:


### PR DESCRIPTION
Fixes https://github.com/hukkin/tomli/issues/214

I'm currently not creating a `SupportsRead` because `Protocol`s only appear in Python 3.8 and we need to support 3.7 (and I don't want a `typing-extensions` dependency).