### PR TITLE
Use sys.version_info in compatibility layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ tomli >= 1.1.0 ; python_version < "3.11"
 Then, in your code, import a TOML parser using the following fallback mechanism:
 
 ```python
-try:
+import sys
+if sys.version_info >= (3, 11):
     import tomllib
-except ModuleNotFoundError:
+else:
     import tomli as tomllib
 
 tomllib.loads("['This parses fine with Python 3.6+']")

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Then, in your code, import a TOML parser using the following fallback mechanism:
 
 ```python
 import sys
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:


### PR DESCRIPTION
Fixes #219

Static type checkers are able to understand checks against sys.version_info much better than try-except. In general, if type checkers tried to handle conditional imports fancily, this would result in unsoundness.

Another reason is that you may have tomli conditionally installed based on Python version, in which case a type checker would not even have a way of knowing what tomli is, but with a sys.version check it knows it doesn't need to know that.