### PR TITLE
Add support for Python 3.12, drop EOL 3.7

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,8 +32,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['pypy3.10', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['pypy3.10', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev']
         os: [ubuntu-latest, macos-latest, windows-latest]
+    continue-on-error: ${{ matrix.python-version == '3.13-dev' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
 
@@ -37,10 +37,10 @@ jobs:
     continue-on-error: ${{ matrix.python-version == '3.12-dev' }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -55,8 +55,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install package and coverage deps
@@ -70,7 +70,7 @@ jobs:
         coverage run -m unittest
         coverage report --fail-under=100
     - name: Report coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
 
   allgood:
     runs-on: ubuntu-latest
@@ -87,8 +87,8 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.7'
     - name: Install build and publish tools

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,9 +32,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['pypy-3.7', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev']
+        python-version: ['pypy3.10', '3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
-    continue-on-error: ${{ matrix.python-version == '3.12-dev' }}
 
     steps:
     - uses: actions/checkout@v4
@@ -58,7 +57,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.x'
     - name: Install package and coverage deps
       run: |
         pip install . coverage
@@ -90,7 +89,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.x'
     - name: Install build and publish tools
       run: |
         pip install build twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Taneli Hukkinen", email = "hukkin@users.noreply.github.com" },
 ]
 license = { file = "LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 readme = "README.md"
 classifiers = [
     "License :: OSI Approved :: MIT License",
@@ -47,10 +47,10 @@ profile = "black"
 legacy_tox_ini = '''
 [tox]
 # Only run unittest envs when no args given to tox
-envlist = py{37,38,39,310,311}
+envlist = py{38,39,310,311,312}
 isolated_build = True
 
-[testenv:py{37,38,39,310,311}]
+[testenv:py{38,39,310,311,312}]
 description = run tests against a built package
 commands =
     python -m unittest {posargs}


### PR DESCRIPTION
Allow 3.12 to fail the build, and remove 3.7, EOL since 2023-06-27: https://devguide.python.org/versions/