### PR TITLE
GitHub Actions: Detecting the operating system with $runner.os

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,7 +80,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   binary-wheels-standard:
-    name: Binary wheels for ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
+    name: Binary wheels for ${{ runner.os }} being built on ${{ runner.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#detecting-the-operating-system