### PR TITLE
Use Python 3.15 lazy import

### DIFF
--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -710,9 +710,7 @@ def parse_basic_str(src: str, pos: Pos, *, multiline: bool) -> tuple[Pos, str]:
         pos += 1
 
 
-def try_simple_decimal(
-    src: str, pos: Pos
-) -> None | tuple[Pos, int]:
+def try_simple_decimal(src: str, pos: Pos) -> None | tuple[Pos, int]:
     """Parse a "simple" decimal integer.
 
     An optimization that tries to parse a simple decimal integer

--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -795,7 +795,7 @@ def parse_value(
     if USE_SIMPLE_DECIMAL:
         number = try_simple_decimal(src, pos)
         if number is not None:
-            return number
+            return number  # pragma: no cover
 
         # No longer use try_simple_decimal(), switch to regex
         USE_SIMPLE_DECIMAL = False

--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -20,7 +20,7 @@ from ._re import (
     match_to_number,
 )
 
-if sys.version_info < (3, 15):
+if sys.version_info < (3, 15):  # pragma: no cover
     from types import MappingProxyType as frozendict
 
 TYPE_CHECKING = False

--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -712,6 +712,7 @@ def parse_basic_str(src: str, pos: Pos, *, multiline: bool) -> tuple[Pos, str]:
 
 USE_SIMPLE_DECIMAL = True
 
+
 def try_simple_decimal(src: str, pos: Pos) -> None | tuple[Pos, int]:
     """Parse a "simple" decimal integer.
 

--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -5,7 +5,11 @@
 from __future__ import annotations
 
 import sys
-from types import MappingProxyType
+
+# Defer loading regular expressions until we actually need them in
+# parse_value(). Before that, use try_simple_decimal() to parse simple
+# decimal numbers.
+__lazy_modules__ = ["tomli._re"]
 
 from ._re import (
     RE_DATETIME,
@@ -15,6 +19,9 @@ from ._re import (
     match_to_localtime,
     match_to_number,
 )
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -61,7 +68,18 @@ BARE_KEY_CHARS: Final = frozenset(
 KEY_INITIAL_CHARS: Final = BARE_KEY_CHARS | frozenset("\"'")
 HEXDIGIT_CHARS: Final = frozenset("abcdef" "ABCDEF" "0123456789")
 
-BASIC_STR_ESCAPE_REPLACEMENTS: Final = MappingProxyType(
+# If one of these follows a "simple decimal" it could mean that
+# the value is actually something else (float, datetime...), so
+# optimized parsing should be abandoned.
+ILLEGAL_AFTER_SIMPLE_DECIMAL: Final = frozenset(
+    "eE."  # decimal
+    "xbo"  # hex, bin, oct
+    "-"  # datetime
+    ":"  # localtime
+    "_0123456789"  # complex decimal
+)
+
+BASIC_STR_ESCAPE_REPLACEMENTS: Final = frozendict(
     {
         "\\b": "\u0008",  # backspace
         "\\t": "\u0009",  # tab
@@ -692,6 +710,37 @@ def parse_basic_str(src: str, pos: Pos, *, multiline: bool) -> tuple[Pos, str]:
         pos += 1
 
 
+def try_simple_decimal(
+    src: str, pos: Pos
+) -> None | tuple[Pos, int]:
+    """Parse a "simple" decimal integer.
+
+    An optimization that tries to parse a simple decimal integer
+    without underscores. Returns `None` if there's any uncertainty
+    on correctness.
+    """
+    start_pos = pos
+
+    if src.startswith(("+", "-"), pos):
+        pos += 1
+
+    if src.startswith("0", pos):
+        pos += 1
+    elif src.startswith(("1", "2", "3", "4", "5", "6", "7", "8", "9"), pos):
+        pos = skip_chars(src, pos, "0123456789")
+    else:
+        return None
+
+    try:
+        next_char = src[pos]
+    except IndexError:
+        next_char = None
+    if next_char in ILLEGAL_AFTER_SIMPLE_DECIMAL:
+        return None
+
+    return pos, int(src[start_pos:pos])
+
+
 def parse_value(
     src: str, pos: Pos, parse_float: ParseFloat, nest_lvl: int
 ) -> tuple[Pos, Any]:
@@ -737,6 +786,13 @@ def parse_value(
     # Inline tables
     if char == "{":
         return parse_inline_table(src, pos, parse_float, nest_lvl + 1)
+
+    # Try a simple parser for decimal numbers. If it's able to parse all
+    # numbers, it avoids importing tomli._re which has an impact on
+    # the tomli startup time.
+    number = try_simple_decimal(src, pos)
+    if number is not None:
+        return number
 
     # Dates and times
     datetime_match = RE_DATETIME.match(src, pos)

--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -795,7 +795,7 @@ def parse_value(
     if USE_SIMPLE_DECIMAL:
         number = try_simple_decimal(src, pos)
         if number is not None:
-            return number  # pragma: no cover
+            return number
 
         # No longer use try_simple_decimal(), switch to regex
         USE_SIMPLE_DECIMAL = False

--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -710,6 +710,8 @@ def parse_basic_str(src: str, pos: Pos, *, multiline: bool) -> tuple[Pos, str]:
         pos += 1
 
 
+USE_SIMPLE_DECIMAL = True
+
 def try_simple_decimal(src: str, pos: Pos) -> None | tuple[Pos, int]:
     """Parse a "simple" decimal integer.
 
@@ -788,9 +790,14 @@ def parse_value(
     # Try a simple parser for decimal numbers. If it's able to parse all
     # numbers, it avoids importing tomli._re which has an impact on
     # the tomli startup time.
-    number = try_simple_decimal(src, pos)
-    if number is not None:
-        return number
+    global USE_SIMPLE_DECIMAL
+    if USE_SIMPLE_DECIMAL:
+        number = try_simple_decimal(src, pos)
+        if number is not None:
+            return number
+
+        # No longer use try_simple_decimal(), switch to regex
+        USE_SIMPLE_DECIMAL = False
 
     # Dates and times
     datetime_match = RE_DATETIME.match(src, pos)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -7,8 +7,10 @@ import datetime
 from decimal import Decimal as D
 import importlib
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 
 from . import tomllib
@@ -154,3 +156,57 @@ class TestMiscellaneous(unittest.TestCase):
         never imported by tests.
         """
         importlib.import_module(f"{tomllib.__name__}._types")
+
+    def test_try_simple_decimal(self):
+        try_simple_decimal = tomllib._parser.try_simple_decimal
+        self.assertEqual(try_simple_decimal("123", 0), (3, 123))
+        self.assertEqual(try_simple_decimal("123\n", 0), (3, 123))
+        self.assertEqual(try_simple_decimal("123 456", 0), (3, 123))
+        self.assertEqual(try_simple_decimal("+123\n", 0), (4, 123))
+        self.assertEqual(try_simple_decimal("-123\n", 0), (4, -123))
+        self.assertEqual(try_simple_decimal("0\n", 0), (1, 0))
+        self.assertEqual(try_simple_decimal("+0\n", 0), (2, 0))
+        self.assertEqual(try_simple_decimal("-0\n", 0), (2, 0))
+        self.assertEqual(try_simple_decimal("[23]\n", 1), (3, 23))
+        self.assertEqual(try_simple_decimal("[23, 24]\n", 1), (3, 23))
+        self.assertEqual(try_simple_decimal("{x = 42}\n", 5), (7, 42))
+
+        self.assertIsNone(try_simple_decimal("+", 0), None)
+        self.assertIsNone(try_simple_decimal("-", 0), None)
+        self.assertIsNone(try_simple_decimal("+\n", 0), None)
+        self.assertIsNone(try_simple_decimal("-\n", 0), None)
+        self.assertIsNone(try_simple_decimal("+inf\n", 0), None)
+        self.assertIsNone(try_simple_decimal("-nan\n", 0), None)
+        self.assertIsNone(try_simple_decimal("0123\n", 0))
+        self.assertIsNone(try_simple_decimal("1979-05-27\n", 0))
+        self.assertIsNone(try_simple_decimal("12:32:00\n", 0))
+        self.assertIsNone(try_simple_decimal("1.0\n", 0))
+        self.assertIsNone(try_simple_decimal("1_000\n", 0))
+        self.assertIsNone(try_simple_decimal("0x123\n", 0))
+        self.assertIsNone(try_simple_decimal("0o123\n", 0))
+        self.assertIsNone(try_simple_decimal("0b100\n", 0))
+
+    @unittest.skipUnless(sys.version_info >= (3, 15), 'need Python 3.15+')
+    def test_lazy_import(self):
+        # Test that try_simple_decimal() can parse the TOML file without
+        # importing regular expressions (tomli._re)
+        with tempfile.TemporaryDirectory() as tmp_dir_path:
+            file_path = Path(tmp_dir_path) / "test.toml"
+            toml = textwrap.dedent("""
+                [metadata]
+                int = 123
+                list = [+1, -2, 3]
+                table = {x=1, y=2}
+            """)
+            with open(file_path, "w") as fp:
+                fp.write(toml)
+
+            code = textwrap.dedent(f"""
+                import sys, tomli
+                with open({str(file_path)!a}, "rb") as fp:
+                    tomli.load(fp)
+                print("lazy import?", 'tomli._re' not in sys.modules)
+            """)
+            cmd = [sys.executable, '-c', code]
+            proc = subprocess.run(cmd, check=True, capture_output=True)
+            self.assertIn(b'lazy import? True', proc.stdout.rstrip())

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -186,6 +186,25 @@ class TestMiscellaneous(unittest.TestCase):
         self.assertIsNone(try_simple_decimal("0o123\n", 0))
         self.assertIsNone(try_simple_decimal("0b100\n", 0))
 
+    def test_use_simple_decimal(self):
+        # USE_SIMPLE_DECIMAL remains True if parsing only simple numbers
+        toml = textwrap.dedent("""
+            [metadata]
+            only_ints = [123, 456]
+        """)
+        tomllib._parser.USE_SIMPLE_DECIMAL = True
+        tomllib.loads(toml)
+        self.assertTrue(tomllib._parser.USE_SIMPLE_DECIMAL)
+
+        # Turn off USE_SIMPLE_DECIMAL when meeting the first non-simple number
+        # (a datetime in this case)
+        toml = textwrap.dedent("""
+            [metadata]
+            datatime = 2007-02-01T17:09:54-08:45
+        """)
+        tomllib.loads(toml)
+        self.assertFalse(tomllib._parser.USE_SIMPLE_DECIMAL)
+
     @unittest.skipUnless(sys.version_info >= (3, 15), "need Python 3.15+")
     def test_lazy_import(self):
         # Test that try_simple_decimal() can parse the TOML file without

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -186,7 +186,7 @@ class TestMiscellaneous(unittest.TestCase):
         self.assertIsNone(try_simple_decimal("0o123\n", 0))
         self.assertIsNone(try_simple_decimal("0b100\n", 0))
 
-    @unittest.skipUnless(sys.version_info >= (3, 15), 'need Python 3.15+')
+    @unittest.skipUnless(sys.version_info >= (3, 15), "need Python 3.15+")
     def test_lazy_import(self):
         # Test that try_simple_decimal() can parse the TOML file without
         # importing regular expressions (tomli._re)
@@ -207,6 +207,6 @@ class TestMiscellaneous(unittest.TestCase):
                     tomli.load(fp)
                 print("lazy import?", 'tomli._re' not in sys.modules)
             """)
-            cmd = [sys.executable, '-c', code]
+            cmd = [sys.executable, "-c", code]
             proc = subprocess.run(cmd, check=True, capture_output=True)
-            self.assertIn(b'lazy import? True', proc.stdout.rstrip())
+            self.assertIn(b"lazy import? True", proc.stdout.rstrip())


### PR DESCRIPTION
Make tomli import time up to 10x faster on Python 3.15. Use Python 3.15 lazy imports to only load regular expressions to parse datetime, localtime or non-trivial numbers (others than just decimal digits). Add try_simple_decimal() parser for simple decimal numbers.

On Python 3.15, use also the new built-in frozendict type (for BASIC_STR_ESCAPE_REPLACEMENTS), instead of types.MappingProxyType.