### PR TITLE
Show missing lines in CI coverage report

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,7 +75,7 @@ jobs:
         rm -rf tests/data/valid/_external/
         rm -rf tests/data/invalid/_external/
         coverage run -m unittest
-        coverage report --fail-under=100
+        coverage report --fail-under=100 --show-missing
     - name: Report coverage
       uses: codecov/codecov-action@v5
       with:


### PR DESCRIPTION
When coverage is missing, the CI report doesn't tell you what to fix -- see for example: https://github.com/hukkin/tomli/actions/runs/23948589205/job/69850336226?pr=292

With `--show-missing`, it'll list the missed lines/branches.