### PR TITLE
Use Python 3.15 lazy import

### DIFF
--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -7,6 +7,10 @@ from __future__ import annotations
 import sys
 from types import MappingProxyType
 
+# Defer loading regular expressions until we actually need them in
+# parse_value().
+__lazy_modules__ = ["tomli._re"]
+
 from ._re import (
     RE_DATETIME,
     RE_LOCALTIME,

--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -4,12 +4,10 @@
 
 from __future__ import annotations
 
-import sys
-from types import MappingProxyType
-
 # Defer loading regular expressions until we actually need them in
 # parse_value().
 __lazy_modules__ = ["tomli._re"]
+
 import sys
 from types import MappingProxyType
 

--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -10,11 +10,6 @@ from types import MappingProxyType
 # Defer loading regular expressions until we actually need them in
 # parse_value().
 __lazy_modules__ = ["tomli._re"]
-
-# Defer loading regular expressions until we actually need them in
-# parse_value().
-__lazy_modules__ = ["tomli._re"]
-
 import sys
 from types import MappingProxyType
 

--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -11,6 +11,13 @@ from types import MappingProxyType
 # parse_value().
 __lazy_modules__ = ["tomli._re"]
 
+# Defer loading regular expressions until we actually need them in
+# parse_value().
+__lazy_modules__ = ["tomli._re"]
+
+import sys
+from types import MappingProxyType
+
 from ._re import (
     RE_DATETIME,
     RE_LOCALTIME,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -7,8 +7,10 @@ import datetime
 from decimal import Decimal as D
 import importlib
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 
 from . import tomllib
@@ -154,3 +156,22 @@ class TestMiscellaneous(unittest.TestCase):
         never imported by tests.
         """
         importlib.import_module(f"{tomllib.__name__}._types")
+
+    @unittest.skipUnless(sys.version_info >= (3, 15), "need Python 3.15+")
+    def test_lazy_import(self):
+        # Test the TOML file can be parsed without importing regular
+        # expressions (tomli._re)
+        code = textwrap.dedent(f"""
+            import sys, tomli, textwrap
+            document = textwrap.dedent('''
+                [metadata]
+                key = "text"
+                array = ["array", "of", "text"]
+                booleans = [true, false]
+            ''')
+            tomli.loads(document)
+            print("lazy import?", 'tomli._re' not in sys.modules)
+        """)
+        cmd = [sys.executable, "-c", code]
+        proc = subprocess.run(cmd, check=True, capture_output=True)
+        self.assertIn(b"lazy import? True", proc.stdout.rstrip())

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -161,7 +161,7 @@ class TestMiscellaneous(unittest.TestCase):
     def test_lazy_import(self):
         # Test the TOML file can be parsed without importing regular
         # expressions (tomli._re)
-        code = textwrap.dedent(f"""
+        code = textwrap.dedent("""
             import sys, tomli, textwrap
             document = textwrap.dedent('''
                 [metadata]


### PR DESCRIPTION
Use Python 3.15 lazy imports to only load regular expressions when needed: to parse numbers, datetime or localtime.