### PR TITLE
Use frozendict on Python 3.15

### DIFF
--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 __lazy_modules__ = ["tomli._re"]
 
 import sys
-from types import MappingProxyType
 
 from ._re import (
     RE_DATETIME,
@@ -19,6 +18,9 @@ from ._re import (
     match_to_localtime,
     match_to_number,
 )
+
+if sys.version_info < (3, 15):  # pragma: no cover
+    from types import MappingProxyType as frozendict
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -65,7 +67,7 @@ BARE_KEY_CHARS: Final = frozenset(
 KEY_INITIAL_CHARS: Final = BARE_KEY_CHARS | frozenset("\"'")
 HEXDIGIT_CHARS: Final = frozenset("abcdef" "ABCDEF" "0123456789")
 
-BASIC_STR_ESCAPE_REPLACEMENTS: Final = MappingProxyType(
+BASIC_STR_ESCAPE_REPLACEMENTS: Final = frozendict(
     {
         "\\b": "\u0008",  # backspace
         "\\t": "\u0009",  # tab


### PR DESCRIPTION
On Python 3.15, use the new built-in type frozendict, instead of types.MappingProxyType, for BASIC_STR_ESCAPE_REPLACEMENTS constant.