### PR TITLE
(low priority) Improve tomllib compatibility and sync docs

### DIFF
--- a/src/tomli/_parser.py
+++ b/src/tomli/_parser.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 # Defer loading regular expressions until we actually need them in
 # parse_value().
-__lazy_modules__ = ["tomli._re"]
+__lazy_modules__ = ["tomli._re", "tomllib._re"]
 
 import sys
 

--- a/tomllib.md
+++ b/tomllib.md
@@ -35,7 +35,6 @@ matches Tomli commit https://github.com/hukkin/tomli/commit/7e563eed5286b5d46b82
 
   from . import load_tests
 
-
   unittest.main()
   ```
 
@@ -44,6 +43,7 @@ matches Tomli commit https://github.com/hukkin/tomli/commit/7e563eed5286b5d46b82
   ```python
   import os
   from test.support import load_package_tests
+
 
   def load_tests(*args):
       return load_package_tests(os.path.dirname(__file__), *args)

--- a/tomllib.md
+++ b/tomllib.md
@@ -35,6 +35,7 @@ matches Tomli commit https://github.com/hukkin/tomli/commit/7e563eed5286b5d46b82
 
   from . import load_tests
 
+
   unittest.main()
   ```
 
@@ -44,7 +45,6 @@ matches Tomli commit https://github.com/hukkin/tomli/commit/7e563eed5286b5d46b82
   import os
   from test.support import load_package_tests
 
-
   def load_tests(*args):
       return load_package_tests(os.path.dirname(__file__), *args)
   ```
@@ -52,3 +52,14 @@ matches Tomli commit https://github.com/hukkin/tomli/commit/7e563eed5286b5d46b82
   Also change `import tomli as tomllib` to `import tomllib`.
 
 - In `cpython:Lib/tomllib/_parser.py` replace `__fp` with `fp` and `__s` with `s`. Add the `/` to `load` and `loads` function signatures.
+
+- Add the following to `cpython:Lib/tomllib/__init__.py`:
+
+  ```python
+  # Pretend this exception was created here.
+  TOMLDecodeError.__module__ = __name__
+  ```
+
+- Restore `cpython:Lib/tomllib/mypy.ini`
+
+- Examine the diff, and revert mypyc-related changes in code and tests.


### PR DESCRIPTION
- Add "tomllib._re" to `__lazy_modules__`. (Should be harmless; `tomllib` should get that in the next feature sync.)
- Adjust whitespace in `tomllib.md` to match what's in CPython
- Add a few additional steps