### PR TITLE
chore: improve tomli maintenance path

### DIFF
--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -102,3 +102,68 @@ class TestError(unittest.TestCase):
         self.assertEqual(e.pos, pos)
         self.assertEqual(e.lineno, 3)
         self.assertEqual(e.colno, 2)
+
+    def test_edge_case_pos_and_message(self):
+        # Unterminated multi-line basic string
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads('a = """hello')
+        self.assertEqual(exc_info.exception.msg, "Unterminated string")
+        self.assertEqual(exc_info.exception.pos, 12)
+        self.assertEqual(str(exc_info.exception), "Unterminated string (at end of document)")
+        self.assertEqual(exc_info.exception.lineno, 1)
+        self.assertEqual(exc_info.exception.colno, 13)
+
+        # Unterminated multi-line literal string
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads("a = '''hello")
+        self.assertEqual(exc_info.exception.msg, "Expected \"'''\"")
+        self.assertEqual(exc_info.exception.pos, 12)
+        self.assertEqual(str(exc_info.exception), "Expected \"'''\" (at end of document)")
+        self.assertEqual(exc_info.exception.lineno, 1)
+        self.assertEqual(exc_info.exception.colno, 13)
+
+        # Malformed inline table: missing '=' after key
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads("a = { b = 1, c }")
+        self.assertEqual(
+            exc_info.exception.msg, "Expected '=' after a key in a key/value pair"
+        )
+        self.assertEqual(exc_info.exception.pos, 15)
+        self.assertEqual(
+            str(exc_info.exception),
+            "Expected '=' after a key in a key/value pair (at line 1, column 16)",
+        )
+        self.assertEqual(exc_info.exception.lineno, 1)
+        self.assertEqual(exc_info.exception.colno, 16)
+
+        # Unclosed inline table
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads("a = { b = 1")
+        self.assertEqual(exc_info.exception.msg, "Unclosed inline table")
+        self.assertEqual(exc_info.exception.pos, 11)
+        self.assertEqual(
+            str(exc_info.exception), "Unclosed inline table (at end of document)"
+        )
+        self.assertEqual(exc_info.exception.lineno, 1)
+        self.assertEqual(exc_info.exception.colno, 12)
+
+        # Invalid date (regex matches but datetime() rejects)
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads("a = 2021-02-30")
+        self.assertEqual(exc_info.exception.msg, "Invalid date or datetime")
+        self.assertEqual(exc_info.exception.pos, 4)
+        self.assertEqual(
+            str(exc_info.exception),
+            "Invalid date or datetime (at line 1, column 5)",
+        )
+        self.assertEqual(exc_info.exception.lineno, 1)
+        self.assertEqual(exc_info.exception.colno, 5)
+
+        # Multi-line unterminated string on a later line
+        with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
+            tomllib.loads("a = 1\n\nb = \"\"\"hello\nworld")
+        self.assertEqual(exc_info.exception.msg, "Unterminated string")
+        self.assertEqual(exc_info.exception.pos, 25)
+        self.assertEqual(str(exc_info.exception), "Unterminated string (at end of document)")
+        self.assertEqual(exc_info.exception.lineno, 4)
+        self.assertEqual(exc_info.exception.colno, 6)

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -109,7 +109,9 @@ class TestError(unittest.TestCase):
             tomllib.loads('a = """hello')
         self.assertEqual(exc_info.exception.msg, "Unterminated string")
         self.assertEqual(exc_info.exception.pos, 12)
-        self.assertEqual(str(exc_info.exception), "Unterminated string (at end of document)")
+        self.assertEqual(
+            str(exc_info.exception), "Unterminated string (at end of document)"
+        )
         self.assertEqual(exc_info.exception.lineno, 1)
         self.assertEqual(exc_info.exception.colno, 13)
 
@@ -118,7 +120,9 @@ class TestError(unittest.TestCase):
             tomllib.loads("a = '''hello")
         self.assertEqual(exc_info.exception.msg, "Expected \"'''\"")
         self.assertEqual(exc_info.exception.pos, 12)
-        self.assertEqual(str(exc_info.exception), "Expected \"'''\" (at end of document)")
+        self.assertEqual(
+            str(exc_info.exception), "Expected \"'''\" (at end of document)"
+        )
         self.assertEqual(exc_info.exception.lineno, 1)
         self.assertEqual(exc_info.exception.colno, 13)
 
@@ -161,9 +165,11 @@ class TestError(unittest.TestCase):
 
         # Multi-line unterminated string on a later line
         with self.assertRaises(tomllib.TOMLDecodeError) as exc_info:
-            tomllib.loads("a = 1\n\nb = \"\"\"hello\nworld")
+            tomllib.loads('a = 1\n\nb = """hello\nworld')
         self.assertEqual(exc_info.exception.msg, "Unterminated string")
         self.assertEqual(exc_info.exception.pos, 25)
-        self.assertEqual(str(exc_info.exception), "Unterminated string (at end of document)")
+        self.assertEqual(
+            str(exc_info.exception), "Unterminated string (at end of document)"
+        )
         self.assertEqual(exc_info.exception.lineno, 4)
         self.assertEqual(exc_info.exception.colno, 6)


### PR DESCRIPTION
Summary:
- Add focused unit tests covering specific TOMLDecodeError edge cases (e.g., precise line/column reporting for malformed inline tables, unterminated multi-line strings, or invalid datetime offsets) — verifying the exception message and pos attribute, not changing parser behavior.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.