### PR TITLE
ci: migrate PyPI publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -147,6 +147,9 @@ jobs:
     needs: [ allgood ]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
     - uses: actions/download-artifact@v7
       with:
@@ -156,13 +159,9 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: '3.x'
-    - name: Install twine
+    - name: Check distributions
       run: |
         pip install twine
-    - name: Check and publish
-      run: |
         twine check --strict dist/*
-        twine upload dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Closes #291

## What this changes

Replaces the `twine upload` + `PYPI_TOKEN` secret approach in the `pypi-publish` job with PyPA's [Trusted Publishing (OIDC)](https://docs.pypi.org/trusted-publishers/) via `pypa/gh-action-pypi-publish`.

The `twine check --strict` validation step is preserved as a separate pre-publish gate — distributions are checked before the publish action runs.

## Diff summary

- Added `environment: pypi` and `permissions: id-token: write` to the job
- Split the old single step into two: `Check distributions` (twine check) and `Publish to PyPI` (gh-action-pypi-publish)
- Removed `TWINE_USERNAME`/`TWINE_PASSWORD` secret references

## Two maintainer steps required to activate

1. **GitHub:** Go to Settings → Environments → New environment, name it `pypi`
2. **PyPI:** Go to the `tomli` package → Publishing → Add a new publisher:
   - Owner: `hukkin`
   - Repository: `tomli`
   - Workflow: `tests.yaml`
   - Environment: `pypi`

Once both are configured, the next tagged release will publish via OIDC with no long-lived secrets required.

## Why bother

Trusted Publishing is now the recommended approach by PyPA. It eliminates the need to rotate `PYPI_TOKEN` and removes the risk of secret exposure in logs or forks. The change is surgical — only the publish job is touched; all build, test, and lint jobs are unmodified.